### PR TITLE
Mantodean Continued-2026.08.18

### DIFF
--- a/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/AbilityDef/15592.xml
+++ b/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/AbilityDef/15592.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   <L24_Ability_MantoAcidSpit.label>산성 타액</L24_Ability_MantoAcidSpit.label>
   <L24_Ability_MantoAcidSpit.description>목의 샘에서 분비되는 끈적거리는 산성 물질을 입을 통해 분출합니다. 산은 목표에 달라붙어 화상을 입힙니다.</L24_Ability_MantoAcidSpit.description>
-  <L24_Ability_HopperWings.label>황충 날개</L24_Ability_HopperWings.label>
-  <L24_Ability_HopperWings.description>황충 날개를 통해 먼 지점까지 도약합니다.</L24_Ability_HopperWings.description>
+  <L24_Ability_HopperWings.label>황충날개</L24_Ability_HopperWings.label>
+  <L24_Ability_HopperWings.description>황충날개를 통해 먼 지점까지 도약합니다.</L24_Ability_HopperWings.description>
   <L24_Ability_HopperWings.verbProperties.label>도약</L24_Ability_HopperWings.verbProperties.label>
 </LanguageData>

--- a/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/GeneDef/15589.xml
+++ b/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/GeneDef/15589.xml
@@ -1,80 +1,80 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
-	<L24_Carapace_DarkGreen.label>dark green carapace</L24_Carapace_DarkGreen.label>
-	<L24_Carapace_DarkGreen.labelShortAdj>dark green</L24_Carapace_DarkGreen.labelShortAdj>
-	<L24_Carapace_DarkGreen.description>Carriers of this gene see their skin turn into a carapace of dark green color.</L24_Carapace_DarkGreen.description>
-	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.0.symbol>forest</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.0.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.1.symbol>dark</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.1.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.2.symbol>pitch</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.2.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.3.symbol>shadow</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.3.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.4.symbol>green</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.4.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.5.symbol>sage</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.5.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.suffixSymbols.0.symbol>shadow</L24_Carapace_DarkGreen.symbolPack.suffixSymbols.0.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.suffixSymbols.1.symbol>forest</L24_Carapace_DarkGreen.symbolPack.suffixSymbols.1.symbol>
-	<L24_Carapace_DarkGreen.symbolPack.suffixSymbols.2.symbol>sage</L24_Carapace_DarkGreen.symbolPack.suffixSymbols.2.symbol>
-	<L24_Carapace_DarkBrownYellow.label>dark brown yellow carapace</L24_Carapace_DarkBrownYellow.label>
-	<L24_Carapace_DarkBrownYellow.labelShortAdj>dark brown yellow</L24_Carapace_DarkBrownYellow.labelShortAdj>
-	<L24_Carapace_DarkBrownYellow.description>Carriers of this gene see their skin turn into a carapace of dark brown-yellow color.</L24_Carapace_DarkBrownYellow.description>
-	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.0.symbol>forest</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.0.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.1.symbol>dark</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.1.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.2.symbol>pitch</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.2.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.3.symbol>shadow</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.3.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.4.symbol>green</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.4.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.5.symbol>sage</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.5.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.0.symbol>shadow</L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.0.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.1.symbol>forest</L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.1.symbol>
-	<L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.2.symbol>sage</L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.2.symbol>
-	<L24_Carapace_GreyPurple.label>grey purple carapace</L24_Carapace_GreyPurple.label>
-	<L24_Carapace_GreyPurple.labelShortAdj>grey purple</L24_Carapace_GreyPurple.labelShortAdj>
-	<L24_Carapace_GreyPurple.description>Carriers of this gene see their skin turn into a carapace of grey-purple color.</L24_Carapace_GreyPurple.description>
-	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.0.symbol>forest</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.0.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.1.symbol>dark</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.1.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.2.symbol>pitch</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.2.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.3.symbol>shadow</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.3.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.4.symbol>green</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.4.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.5.symbol>sage</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.5.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.suffixSymbols.0.symbol>shadow</L24_Carapace_GreyPurple.symbolPack.suffixSymbols.0.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.suffixSymbols.1.symbol>forest</L24_Carapace_GreyPurple.symbolPack.suffixSymbols.1.symbol>
-	<L24_Carapace_GreyPurple.symbolPack.suffixSymbols.2.symbol>sage</L24_Carapace_GreyPurple.symbolPack.suffixSymbols.2.symbol>
-	<L24_Carapace_LightGreyGreen.label>light grey green carapace</L24_Carapace_LightGreyGreen.label>
-	<L24_Carapace_LightGreyGreen.labelShortAdj>light grey green</L24_Carapace_LightGreyGreen.labelShortAdj>
-	<L24_Carapace_LightGreyGreen.description>Carriers of this gene see their skin turn into a carapace of light grey-green color.</L24_Carapace_LightGreyGreen.description>
-	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.0.symbol>forest</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.0.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.1.symbol>dark</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.1.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.2.symbol>pitch</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.2.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.3.symbol>shadow</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.3.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.4.symbol>green</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.4.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.5.symbol>sage</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.5.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.0.symbol>shadow</L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.0.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.1.symbol>forest</L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.1.symbol>
-	<L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.2.symbol>sage</L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.2.symbol>
+	<L24_Carapace_DarkGreen.label>암록색 외갑</L24_Carapace_DarkGreen.label>
+	<L24_Carapace_DarkGreen.labelShortAdj>암록색</L24_Carapace_DarkGreen.labelShortAdj>
+	<L24_Carapace_DarkGreen.description>이 유전자 보유자는 피부가 암록색 외갑으로 보이게끔 합니다.</L24_Carapace_DarkGreen.description>
+	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.0.symbol>선명한</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.0.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.1.symbol>짙은</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.1.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.2.symbol>부드러운</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.2.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.3.symbol>음영진</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.3.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.4.symbol>창백한</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.4.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.prefixSymbols.5.symbol>밝은</L24_Carapace_DarkGreen.symbolPack.prefixSymbols.5.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.suffixSymbols.0.symbol>음영진</L24_Carapace_DarkGreen.symbolPack.suffixSymbols.0.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.suffixSymbols.1.symbol>선명한</L24_Carapace_DarkGreen.symbolPack.suffixSymbols.1.symbol>
+	<L24_Carapace_DarkGreen.symbolPack.suffixSymbols.2.symbol>밝은</L24_Carapace_DarkGreen.symbolPack.suffixSymbols.2.symbol>
+	<L24_Carapace_DarkBrownYellow.label>황토색 외갑</L24_Carapace_DarkBrownYellow.label>
+	<L24_Carapace_DarkBrownYellow.labelShortAdj>황토색</L24_Carapace_DarkBrownYellow.labelShortAdj>
+	<L24_Carapace_DarkBrownYellow.description>이 유전자 보유자는 피부가 황토색 외갑으로 보이게끔 합니다.</L24_Carapace_DarkBrownYellow.description>
+	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.0.symbol>선명한</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.0.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.1.symbol>짙은</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.1.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.2.symbol>부드러운</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.2.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.3.symbol>음영진</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.3.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.4.symbol>창백한</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.4.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.5.symbol>밝은</L24_Carapace_DarkBrownYellow.symbolPack.prefixSymbols.5.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.0.symbol>음영진</L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.0.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.1.symbol>선명한</L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.1.symbol>
+	<L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.2.symbol>밝은</L24_Carapace_DarkBrownYellow.symbolPack.suffixSymbols.2.symbol>
+	<L24_Carapace_GreyPurple.label>회자주색 외갑</L24_Carapace_GreyPurple.label>
+	<L24_Carapace_GreyPurple.labelShortAdj>회자주색</L24_Carapace_GreyPurple.labelShortAdj>
+	<L24_Carapace_GreyPurple.description>이 유전자 보유자는 피부가 회자주색 외갑으로 보이게끔 합니다.</L24_Carapace_GreyPurple.description>
+	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.0.symbol>선명한</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.0.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.1.symbol>짙은</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.1.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.2.symbol>부드러운</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.2.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.3.symbol>음영진</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.3.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.4.symbol>창백한</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.4.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.prefixSymbols.5.symbol>밝은</L24_Carapace_GreyPurple.symbolPack.prefixSymbols.5.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.suffixSymbols.0.symbol>음영진</L24_Carapace_GreyPurple.symbolPack.suffixSymbols.0.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.suffixSymbols.1.symbol>선명한</L24_Carapace_GreyPurple.symbolPack.suffixSymbols.1.symbol>
+	<L24_Carapace_GreyPurple.symbolPack.suffixSymbols.2.symbol>밝은</L24_Carapace_GreyPurple.symbolPack.suffixSymbols.2.symbol>
+	<L24_Carapace_LightGreyGreen.label>밝은 회녹색 외갑</L24_Carapace_LightGreyGreen.label>
+	<L24_Carapace_LightGreyGreen.labelShortAdj>회녹색</L24_Carapace_LightGreyGreen.labelShortAdj>
+	<L24_Carapace_LightGreyGreen.description>이 유전자 보유자는 피부가 밝은 회녹색 외갑으로 보이게끔 합니다.</L24_Carapace_LightGreyGreen.description>
+	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.0.symbol>선명한</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.0.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.1.symbol>짙은</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.1.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.2.symbol>부드러운</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.2.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.3.symbol>음영진</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.3.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.4.symbol>창백한</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.4.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.5.symbol>밝은</L24_Carapace_LightGreyGreen.symbolPack.prefixSymbols.5.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.0.symbol>음영진</L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.0.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.1.symbol>선명한</L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.1.symbol>
+	<L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.2.symbol>밝은</L24_Carapace_LightGreyGreen.symbolPack.suffixSymbols.2.symbol>
   <L24_Gene_MantoPollutionRush.label>공해 자극</L24_Gene_MantoPollutionRush.label>
   <L24_Gene_MantoPollutionRush.description>이 유전자의 보유자는 오염에 노출되면 화학물질이 분비됩니다. 이를 통해 빠르게 움직이고 명확하게 판단을 내릴 수 있습니다. 비슷한 유전자는 생체병기로 제작된 거대 곤충에게서 찾을 수 있습니다.</L24_Gene_MantoPollutionRush.description>
   <L24_Gene_MantoPollutionRush.customEffectDescriptions.0>오염에 노출될 때 추가 능력치를 얻습니다.</L24_Gene_MantoPollutionRush.customEffectDescriptions.0>
-	<L24_Gene_MantodeanFlesh.label>mantodean flesh</L24_Gene_MantodeanFlesh.label>
-	<L24_Gene_MantodeanFlesh.description>Carriers of this gene have mantodean tissue for flesh. Consuming mantodean meat by them is classed as cannibalism. When butchered, they will yield mantodean meat instead of human meat.</L24_Gene_MantodeanFlesh.description>
-	<L24_Gene_HoppperWings.label>hopper wings</L24_Gene_HoppperWings.label>
-	<L24_Gene_HoppperWings.description>Carriers have special hemogen-powered muscle fibers in their legs which allow them to jump great distances.</L24_Gene_HoppperWings.description>
-	<L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.0.symbol>jumper</L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.0.symbol>
-	<L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.1.symbol>leaper</L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.1.symbol>
-	<L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.2.symbol>bouncer</L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.2.symbol>
-	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.0.symbol>jump</L24_Gene_HoppperWings.symbolPack.prefixSymbols.0.symbol>
-	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.1.symbol>leap</L24_Gene_HoppperWings.symbolPack.prefixSymbols.1.symbol>
-	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.2.symbol>vault</L24_Gene_HoppperWings.symbolPack.prefixSymbols.2.symbol>
-	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.3.symbol>long</L24_Gene_HoppperWings.symbolPack.prefixSymbols.3.symbol>
-	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.4.symbol>fly</L24_Gene_HoppperWings.symbolPack.prefixSymbols.4.symbol>
-	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.5.symbol>hop</L24_Gene_HoppperWings.symbolPack.prefixSymbols.5.symbol>
-	<L24_Gene_VoiceMantodean.label>mantodean voice</L24_Gene_VoiceMantodean.label>
-	<L24_Gene_VoiceMantodean.description>Carriers have a insectile voice that often includes clicks, clacks and trills. Sometimes its rather musical in nature or harsh like a thoousand insectile legs clattering against stone. Mantodeans speak like this.</L24_Gene_VoiceMantodean.description>
-	<L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.0.symbol>clicker</L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.0.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.1.symbol>clacker</L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.1.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.2.symbol>triller</L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.2.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.0.symbol>click</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.0.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.1.symbol>clack</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.1.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.2.symbol>whistle</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.2.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.3.symbol>scream</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.3.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.0.symbol>clacker</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.0.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.1.symbol>bug</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.1.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.2.symbol>insect</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.2.symbol>
-	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.3.symbol>triller</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.3.symbol>
+	<L24_Gene_MantodeanFlesh.label>맨토디안 살</L24_Gene_MantodeanFlesh.label>
+	<L24_Gene_MantodeanFlesh.description>이 유전자 보유자는 맨토디안 조직이 살을 이루고 있습니다. 맨토디안 고기의 섭취는 식인으로 분류됩니다. 도축 시 인육 대신 맨토디안 고기를 수확합니다.</L24_Gene_MantodeanFlesh.description>
+	<L24_Gene_HoppperWings.label>황충날개</L24_Gene_HoppperWings.label>
+	<L24_Gene_HoppperWings.description>이 유전자 보유자는 다리에 먼 거리를 도약하게 해 주는 혈행이 있는 근섬유가 있습니다.</L24_Gene_HoppperWings.description>
+	<L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.0.symbol>뜀벌레</L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.0.symbol>
+	<L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.1.symbol>리퍼</L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.1.symbol>
+	<L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.2.symbol>바운서</L24_Gene_HoppperWings.symbolPack.wholeNameSymbols.2.symbol>
+	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.0.symbol>뜀</L24_Gene_HoppperWings.symbolPack.prefixSymbols.0.symbol>
+	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.1.symbol>도약</L24_Gene_HoppperWings.symbolPack.prefixSymbols.1.symbol>
+	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.2.symbol>넘기</L24_Gene_HoppperWings.symbolPack.prefixSymbols.2.symbol>
+	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.3.symbol>긴</L24_Gene_HoppperWings.symbolPack.prefixSymbols.3.symbol>
+	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.4.symbol>비행</L24_Gene_HoppperWings.symbolPack.prefixSymbols.4.symbol>
+	<L24_Gene_HoppperWings.symbolPack.prefixSymbols.5.symbol>뜀</L24_Gene_HoppperWings.symbolPack.prefixSymbols.5.symbol>
+	<L24_Gene_VoiceMantodean.label>맨토디안 목소리</L24_Gene_VoiceMantodean.label>
+	<L24_Gene_VoiceMantodean.description>보유자는 딸깍거리고 딱딱거림, 그리고 진동음을 포함한 곤충 같은 목소리를 가지고 있습니다. 가끔 자연의 음악과도 같은 소리 혹은 수 천 마리의 곤충 다리가 돌 위에서 달그락거리는 것처럼 들리기도 합니다. 맨토디안이 이러한 목소리로 이야기합니다.</L24_Gene_VoiceMantodean.description>
+	<L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.0.symbol>딸깍이는</L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.0.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.1.symbol>딱딱이는</L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.1.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.2.symbol>진동하는</L24_Gene_VoiceMantodean.symbolPack.wholeNameSymbols.2.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.0.symbol>딸깍</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.0.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.1.symbol>딱딱</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.1.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.2.symbol>휘파람</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.2.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.3.symbol>괴성</L24_Gene_VoiceMantodean.symbolPack.prefixSymbols.3.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.0.symbol>딸깍이는</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.0.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.1.symbol>벌레</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.1.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.2.symbol>곤충</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.2.symbol>
+	<L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.3.symbol>진동</L24_Gene_VoiceMantodean.symbolPack.suffixSymbols.3.symbol>
 </LanguageData>

--- a/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/HediffDef/15519.xml
+++ b/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/HediffDef/15519.xml
@@ -281,7 +281,10 @@
   <L24_Hediff_CorpseJelly.label>군체의식 결속</L24_Hediff_CorpseJelly.label>
   <L24_Hediff_CorpseJelly.description>성장한 맨토디안의 군체의식과 연결되어 있습니다. 수많은 맨토디안들의 지식이 그들에게 흘러내립니다.</L24_Hediff_CorpseJelly.description>
   <L24_Hediff_MorphJelly.label>흑녹색 젤리</L24_Hediff_MorphJelly.label>
-  <L24_Hediff_MorphJelly.description>짙은 초록 젤리로 인해 변이되고 있습니다. 맨토디안 전쟁 벌레와 헐크는 맨토디안 지성체로, 나머지는 연료벌레로 변이합니다. 더 작은 존재(크기 0.4 미만)은 돌연변이로 인해 사망합니다.</L24_Hediff_MorphJelly.description>
+  <L24_Hediff_MorphJelly.description>짙은 초록 젤리로 인해 변이되고 있습니다. 맨토디안 전쟁 벌레와 헐크는 맨토디안 지성체로, 나머지는 연료피드로 변이합니다. 더 작은 존재(크기 0.4 미만)은 돌연변이로 인해 사망합니다.</L24_Hediff_MorphJelly.description>
+  <L24_Manto_HivemindAmplifier.label>군체결속</L24_Manto_HivemindAmplifier.label>
+  <L24_Manto_HivemindAmplifier.description>거대한 군체의식과의 유기적인 연결입니다. 이를 통해 맨토디안은 먼 거리에 있는 군체의식을 정신적으로 유도하여 불가능해 보이는 방식으로 현실에 개입하도록 합니다.\n\n높은 수준의 군체결속은 사용자에게 더 많은 능력을 사용할 수 있도록 합니다. 군체결속의 수준과 무관하게, 맨토디안은 습득한 특정 능력만 사용할 수 있습니다.\n\n군체결속은 다양한 방법으로 얻을 수 있습니다. 일회용 군체의식 증폭기는 군체결속을 만들 수 있습니다. 자신들만의 군체의식을 창조한 군체는 명상을 통해 군체결속을 더 강하게 할 수 있습니다. \n\n뇌내 현상인 군체결속은 연구하려 하면 스스로를 숨기려는 특성 때문에 학계에 잘 알려져 있지 않습니다. 대부분의 사람들이 동의하는 것은 군체결속이 양자얽힘과 유사한 구조로 맨토디안들을 더 강한 군체의식과 연결하고 그들의 힘을 사용하도록 한다는 것입니다.</L24_Manto_HivemindAmplifier.description>
+  <L24_Manto_HivemindAmplifier.descriptionShort>맨토디안이 군체의식을 유도하여 불가능해 보이는 방식으로 현실에 개입하도록 합니다. 높은 수준의 군체결속은 사용자에게 더 많은 능력을 사용할 수 있도록 합니다.</L24_Manto_HivemindAmplifier.descriptionShort>
   <L24_Mutagen_WreathedClaw.label>변이된 팔 (둥근 집게)</L24_Mutagen_WreathedClaw.label>
   <L24_Mutagen_WreathedClaw.description>극도로 돌연변이를 일으키는 인자. 맨토디안의 집게발 부위에 주입하면 조직의 대부분을 새로운 반유기 합성물질로 대체된 집게발로 조직적인 성장을 일으킵니다. 
 이 돌연변이는 발톱을 군체결속을 통하든 초능력 증폭기를 통하든 상관없이 정신 에너지를 집중할 수 있는 특수 발톱으로 변이시킵니다. 발톱은 맨토디안 실크 섬유, 돌연변이 및 블루 젤리로 감겨져 있어 신비한 능력과 힘을 발휘합니다.

--- a/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/ThingDef/15606.xml
+++ b/Data/Mantodeans Continued - 2856039567/Languages/Korean (한국어)/DefInjected/ThingDef/15606.xml
@@ -1079,7 +1079,7 @@ MAL-01 유형의 산성 발사기로 분류된 이 무기의 기록은 최초의
 이 끔찍한 변이는 유기된 함선 내에서 놀라울 정도로 활성화된 군집의 맨토디안들에게서 발견됐네. 먼 변방계의 버려진 키즈라이트 우주 정거장에서 처음으로 기록되었고, 이제는 다른 우주 정거장과 버려진 함선에서도 발견되네.
 조우하는 모든 것들을 파괴하고 그 아래 행성은 유리화 해버리게.
 	</L24_Mutagen_VacuumSac.description>
-	<L24_Mutagen_SealedEyeSet.label>맨토디안 밀폐된 눈무리 변이 </L24_Mutagen_SealedEyeSet.label>
+	<L24_Mutagen_SealedEyeSet.label>맨토디안 밀폐된 눈무리 변이</L24_Mutagen_SealedEyeSet.label>
 	<L24_Mutagen_SealedEyeSet.description>
 극도로 돌연변이를 일으키는 인자. 맨토디안의 눈에 주입하면 얇고 투시가 가능한 조직을 한 쪽 눈무리에 자라게 하는 통제된 돌연변이를 유발합니다.
 이런 껍질은 우주의 진공으로부터 눈을 밀폐하며 감광성을 향상시킵니다.
@@ -1087,10 +1087,10 @@ MAL-01 유형의 산성 발사기로 분류된 이 무기의 기록은 최초의
 제국 보고서:
 이 끔찍한 변이는 유기된 함선 내에서 놀라울 정도로 활성화된 군집의 맨토디안들에게서 발견됐네. 먼 변방계의 버려진 키즈라이트 우주 정거장에서 처음으로 기록되었고, 이제는 다른 우주 정거장과 버려진 함선에서도 발견되네.
 조우하는 모든 것들을 파괴하고 그 아래 행성은 유리화 해버리게.
-	</L24_Mutagen_SealedEyeSet.description>
+</L24_Mutagen_SealedEyeSet.description>
 	
 	<L24_Manto_HivemindAmplifier.label>군체의식 증폭기</L24_Manto_HivemindAmplifier.label>
   <L24_Manto_HivemindAmplifier.description>사용자의 의식을 군체의식과 연결하거나 연결을 증강시킬 수 있는 맨토디안 유기물입니다.\n\n안와에 대고 누르면 뇌와 직접 연결되어 재구성됩니다. 그 이후, 이 물건은 파괴됩니다.</L24_Manto_HivemindAmplifier.description>
-  <L24_Manto_HivemindAmplifier.comps.CompUsableImplant.useLabel>신경구성체로 정신망 구성중</L24_Manto_HivemindAmplifier.comps.CompUsableImplant.useLabel>
+  <L24_Manto_HivemindAmplifier.comps.CompUsableImplant.useLabel>군체의식 증폭기로 정신망 구성</L24_Manto_HivemindAmplifier.comps.CompUsableImplant.useLabel>
 
 </LanguageData>


### PR DESCRIPTION
AbilityDef의 황충 날개를 황충날개로 수정-고유명사 느낌이 나도록
GeneDef의 외갑 색(dark brown-yellow는 적합한 색 표본을 찾을 수 없어 AI가 제시한 이름인 Ochre를 번역하여 황토색으로 함), 맨토디안 살, 황충날개, 맨토디안 목소리 번역
HediffDef의 암록색 젤리 항목의 연료벌레를 연료피드로 수정하여 용어 통일, hivelink 항목 추가 및 번역
ThingDef의 군체의식 증폭기 우클릭 시 출력되는 텍스트를 신경구성체로 정신망 구성 중에서 군체의식 증폭기로 정신망 구성으로 수정